### PR TITLE
Bundle plugins do not generate imports for java.* packages

### DIFF
--- a/epub/core/org.eclipse.mylyn.docs.epub.ant/pom.xml
+++ b/epub/core/org.eclipse.mylyn.docs.epub.ant/pom.xml
@@ -27,7 +27,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-RequiredExecutionEnvironment>JavaSE-11</Bundle-RequiredExecutionEnvironment>
                         <Export-Package>org.eclipse.mylyn.docs.epub.ant.*</Export-Package>
-                        <Import-Package>org.apache.tools.ant.*, org.eclipse.mylyn.docs.epub.*, org.eclipse.mylyn.wikitext.*</Import-Package>
+                        <Import-Package>!java.*, org.apache.tools.ant.*, org.eclipse.mylyn.docs.epub.*, org.eclipse.mylyn.wikitext.*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/epub/core/org.eclipse.mylyn.docs.epub.core/pom.xml
+++ b/epub/core/org.eclipse.mylyn.docs.epub.core/pom.xml
@@ -46,7 +46,7 @@
 						<Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
 						<Bundle-RequiredExecutionEnvironment>JavaSE-11</Bundle-RequiredExecutionEnvironment>
 						<Export-Package>org.eclipse.mylyn.docs.epub.internal*;x-internal:=true,org.eclipse.mylyn.docs.epub.core.*, org.eclipse.mylyn.docs.epub.*</Export-Package>
-						<Import-Package>org.apache.tika.*;version="0", org.eclipse.emf.*, org.eclipse.mylyn.wikitext.*</Import-Package>
+						<Import-Package>!java.*, org.apache.tika.*;version="0", org.eclipse.emf.*, org.eclipse.mylyn.wikitext.*</Import-Package>
 					</instructions>
 				</configuration>
 			</plugin>

--- a/wikitext/core/pom.xml
+++ b/wikitext/core/pom.xml
@@ -52,7 +52,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-RequiredExecutionEnvironment>JavaSE-11</Bundle-RequiredExecutionEnvironment>
                         <Export-Package>${project.artifactId}.internal*;x-internal:=true,${project.artifactId}*</Export-Package>
-                        <Import-Package>com.google.common*; version="[${guava.osgi},${guava.osgi.upper})", *</Import-Package>
+                        <Import-Package>!java.*, com.google.common*; version="[${guava.osgi},${guava.osgi.upper})", *</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Create wikitext and epub OSGI bundles that do not add import-package declarations on java.* packages. Excluding java.* packages maintains compatibility with pre-R7 OSGI frameworks.

Declaring explicit bundle imports on java.* packages was introduced with Java 11 as a way for OSGI frameworks to validate the availability of core java packages in the modularized JRE that started with Java 9. However it's unnecessary to declare these bundle imports as documented in the OSGI Core R7 specification
https://docs.osgi.org/specification/osgi.core/7.0.0/framework.module.html#framework.module-execution.environment.