### PR TITLE
Build only latest version of a PR

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,7 @@ pipeline {
 	options {
 		timeout(time: 40, unit: 'MINUTES')
 		buildDiscarder(logRotator(numToKeepStr:'10'))
+		disableConcurrentBuilds(abortPrevious: true)
 	}
 	agent {
 		label "centos-latest"


### PR DESCRIPTION
To keep load on Jenkins lower