### PR TITLE
Introduce Mylyn Docs Jenkins release pipeline job

### DIFF
--- a/Jenkinsfile-release
+++ b/Jenkinsfile-release
@@ -1,0 +1,105 @@
+pipeline {
+	options {
+		buildDiscarder(logRotator(numToKeepStr:'10'))
+		disableConcurrentBuilds(abortPrevious: true)
+		preserveStashes(buildCount: 50)
+		skipStagesAfterUnstable()
+		timeout(time: 40, unit: 'MINUTES')
+		timestamps()
+	}
+	agent {
+		label "centos-latest"
+	}
+	parameters {
+		booleanParam(name: 'PERFORM_RELEASE', defaultValue: false, description: 'True: run all stages of the build, auto release the nexus repository, tag the release, and merge a commit to bump the development version. False: run all stages of the build but do not side-effect nexus or git repository.')
+	}
+	tools {
+		maven 'apache-maven-3.8.6'
+		jdk 'openjdk-jdk17-latest'
+	}
+	stages {
+		stage('Initialize PGP') {
+			steps {
+				withCredentials([file(credentialsId: 'secret-subkeys.asc', variable: 'KEYRING')]) {
+					sh '''
+						gpg --batch --import "${KEYRING}"
+						for fpr in $(gpg --list-keys --with-colons  | awk -F: \'/fpr:/ {print $10}\' | sort -u); 
+						do 
+							echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key ${fpr} trust; 
+						done
+					'''
+				}
+			}
+		}
+		stage('Build and Deploy Maven Artifacts') {
+			steps {
+				withCredentials([string(credentialsId: 'gpg-passphrase', variable: 'KEYRING_PASSPHRASE')]) {
+					wrap([$class: 'Xvnc', useXauthority: true]) {
+						sh 'mvn clean deploy -U -B -V -e -s /home/jenkins/.m2/settings-deploy-ossrh-docs.xml -Psign -Possrh -Dmaven.repo.local=$WORKSPACE/.m2/repository -Dtycho.buildqualifier.format=yyyyMMddHHmm -Dmaven.test.failure.ignore=true -Dmaven.test.error.ignore=true -Ddash.fail=false -Dgpg.passphrase="${KEYRING_PASSPHRASE}" -DautoReleaseAfterClose="${PERFORM_RELEASE}"'
+					}
+				}
+				dir("docs/org.eclipse.mylyn.docs-site/target/repository") {
+					stash includes: '**', name: 'docsSite'
+				}
+			}
+			post {
+				always {
+					archiveArtifacts artifacts: '**/target/*.zip,**/target/work/data/.metadata/.log'
+					junit '**/target/surefire-reports/TEST-*.xml'
+				}
+			}
+		}
+		stage('Deploy Update Site') {
+			steps {
+				dir("docs/org.eclipse.mylyn.docs-site/target/repository") {
+					deleteDir()
+					unstash 'docsSite'
+				}
+				sshagent (['projects-storage.eclipse.org-bot-ssh']) {
+					sh '''#!/bin/bash
+						
+						RELEASE_VERSION="$(grep '\\s*<releaseVersion>.*</releaseVersion>' pom.xml | sed -e 's|\\s*<releaseVersion>\\([0-9]\\+\\.[0-9]\\+\\).*</releaseVersion>.*|\\1|')"
+						RELEASE_VERSION_FULL="$(grep '\\s*<releaseVersion>.*</releaseVersion>' pom.xml | sed -e 's|\\s*<releaseVersion>\\(.*\\)</releaseVersion>.*|\\1|')"
+
+						DOWNLOAD_AREA=/home/data/httpd/download.eclipse.org/mylyn/docs/releases/$RELEASE_VERSION
+						echo "DOWNLOAD_AREA=$DOWNLOAD_AREA"
+
+						DOWNLOAD_AREA_FULL=/home/data/httpd/download.eclipse.org/mylyn/docs/releases/$RELEASE_VERSION_FULL
+						echo "DOWNLOAD_AREA_FULL=$DOWNLOAD_AREA_FULL"
+
+						if [ "${PERFORM_RELEASE}" == "true" ]; then
+							echo "Copying Mylyn Docs update site to file share."
+							ssh genie.mylyn@projects-storage.eclipse.org "\
+								rm -rf  ${DOWNLOAD_AREA} && \
+								mkdir -p ${DOWNLOAD_AREA} && \
+								rm -rf  ${DOWNLOAD_AREA_FULL} && \
+								mkdir -p ${DOWNLOAD_AREA_FULL}"
+							scp -r docs/org.eclipse.mylyn.docs-site/target/repository/* genie.mylyn@projects-storage.eclipse.org:${DOWNLOAD_AREA}
+							scp -r docs/org.eclipse.mylyn.docs-site/target/repository/* genie.mylyn@projects-storage.eclipse.org:${DOWNLOAD_AREA_FULL}
+						fi
+					'''
+				}
+			}
+		}
+		stage('Tag Release') {
+			steps {
+				sshagent (['git.eclipse.org-bot-ssh']) {
+					sh '''
+						git config --global user.email docs-bot@eclipse.org
+						mvn -B -V -e -Ptag-release -DpushChanges="${PERFORM_RELEASE}" -Dtycho.mode=maven build-helper:parse-version scm:tag -pl .
+					'''
+				}
+			}
+		}
+		stage('Bump Development Version') {
+			steps {
+				sshagent (['git.eclipse.org-bot-ssh']) {
+					sh '''
+						git config --global user.email docs-bot@eclipse.org
+						mvn -B -V -e -Pcommit-version-update -DpushChanges="${PERFORM_RELEASE}" -Dtycho.mode=maven build-helper:parse-version versions:set-property antrun:run scm:checkin -pl .
+					'''
+				}
+			}
+		}
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
                 <configuration>
                     <serverId>ossrh</serverId>
                     <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
A new jenkinsfile defines the build and release steps that the associating Jenkins job
(https://ci.eclipse.org/mylyn/view/Docs/job/github-mylyn-docs-release/) will perform. This pipeline is configured to run only against the master branch (trunk).

The pipeline is split into the following stages:

* Initialize PGP: initialize the PGP keys that will be used for jar signing.

* Build and Deploy Maven Artifacts: builds each of the mylyn docs artifacts (jars, p2 repos, etc.) and run all tests. On a successful build, a subset of the wikitext artifacts will be deployed to Nexus.

* Deploy Update Site: copies the docs-site p2 repository from the previous build step to the download.eclipse.org file share.

* Tag Release: tags the commit associated with the mylyn docs release that was just created.

* Bump Development Version: increments the patch version component of the wikitext version (e.g. 3.0.45 -> 3.0.46).

The latter 3 stages can be restarted for a given build using the built-in functionality of the Jenkins Pipeline.

By default, the build steps will execute in dry-run mode (PERFORM_RELEASE = false). In this mode, the deployed maven artifacts will not be released, the docs-site p2 repository will not be copied to download.eclipse.org, and tags/commits will not be pushed to the git repository.