### PR TITLE
Release pipeline releases nexus staging repository automatically

### DIFF
--- a/Jenkinsfile-release
+++ b/Jenkinsfile-release
@@ -35,7 +35,7 @@ pipeline {
 			steps {
 				withCredentials([string(credentialsId: 'gpg-passphrase', variable: 'KEYRING_PASSPHRASE')]) {
 					wrap([$class: 'Xvnc', useXauthority: true]) {
-						sh 'mvn clean deploy -U -B -V -e -s /home/jenkins/.m2/settings-deploy-ossrh-docs.xml -Psign -Possrh -Dmaven.repo.local=$WORKSPACE/.m2/repository -Dtycho.buildqualifier.format=yyyyMMddHHmm -Dmaven.test.failure.ignore=true -Dmaven.test.error.ignore=true -Ddash.fail=false -Dgpg.passphrase="${KEYRING_PASSPHRASE}" -DautoReleaseAfterClose="${PERFORM_RELEASE}"'
+						sh 'mvn clean deploy -U -B -V -e -s /home/jenkins/.m2/settings-deploy-ossrh-docs.xml -Psign -Possrh -Dmaven.repo.local=$WORKSPACE/.m2/repository -Dtycho.buildqualifier.format=yyyyMMddHHmm -Dmaven.test.failure.ignore=true -Dmaven.test.error.ignore=true -Ddash.fail=false -Dgpg.passphrase="${KEYRING_PASSPHRASE}" -Dnexus.autoReleaseAfterClose="${PERFORM_RELEASE}"'
 					}
 				}
 				dir("docs/org.eclipse.mylyn.docs-site/target/repository") {

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <qualifier>-SNAPSHOT</qualifier>
         <tycho-version>3.0.1</tycho-version>
         <tycho.scmUrl>scm:git:https://github.com/eclipse-mylyn/org.eclipse.mylyn.docs</tycho.scmUrl>
+        <nexus.autoReleaseAfterClose>false</nexus.autoReleaseAfterClose>
     </properties>
     <build>
         <pluginManagement>
@@ -107,7 +108,7 @@
                 <configuration>
                     <serverId>ossrh</serverId>
                     <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                    <autoReleaseAfterClose>${nexus.autoReleaseAfterClose}</autoReleaseAfterClose>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
The nexus-staging-maven-plugin is used to deploy wikitext artifacts to a staging repository in Nexus. The plugin has the ability to release the staging repository automatically if the associating autoReleaseAfterClose parameter = true. This means it's unnecessary to manually release the staging repository using the Nexus Repository Manager.

Unfortunately there was a flaw in the root POM that always set the autoReleaseAfterClose parameter to false, even if the user property -DautoReleaseAfterClose=true was passed on the command-line (as it would if the PERFORM_RELEASE build parameter was true). The nexus staging plugin gives precedence to the configuration supplied in the POM.

The plugin configuration in the POM has been updated so that it is now possible to override the autoReleaseAfterClose parameter.