### PR TITLE
Mylyn Docs Site p2 repository includes guava

### DIFF
--- a/target-platform/mylyn-docs.target
+++ b/target-platform/mylyn-docs.target
@@ -29,6 +29,12 @@
 					<type>jar</type>
 				</dependency>
 				<dependency>
+					<groupId>com.google.guava</groupId>
+					<artifactId>failureaccess</artifactId>
+					<version>1.0.1</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
 					<groupId>net.bytebuddy</groupId>
 					<artifactId>byte-buddy-agent</artifactId>
 					<version>1.12.16</version>

--- a/wikitext/ui/org.eclipse.mylyn.wikitext.sdk-feature/feature.xml
+++ b/wikitext/ui/org.eclipse.mylyn.wikitext.sdk-feature/feature.xml
@@ -44,6 +44,20 @@
          unpack="false"/>
 
    <plugin
+         id="com.google.guava"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="com.google.guava.failureaccess"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="org.eclipse.mylyn.wikitext.help.sdk"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
For convenience, include the BND-wrapped google guava plugins in the docs-site p2 repository. This enables Eclipse RCP consumers to resolve both the Mylyn Docs plugins and associating 3rd party runtime dependencies from the same p2 repository. This is particularly helpful for applications using tycho pre-2.6.0 (cannot consider pom dependencies for TP configuration) because the Eclipse OBR does not include Guava 31.1.