### PR TITLE
Simplify target platform and update deps

### DIFF
--- a/target-platform/mylyn-docs.target
+++ b/target-platform/mylyn-docs.target
@@ -3,11 +3,6 @@
 <target name="mylyn-docs" sequenceNumber="2">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-			<unit id="org.junit" version="4.13.2.v20211018-1956"/>
-			<unit id="org.junit.source" version="4.13.2.v20211018-1956"/>
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220830213456/repository"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.license.feature.group" version="2.0.2.v20181016-2210"/>
 			<repository location="https://download.eclipse.org/cbi/updates/license"/>
 		</location>
@@ -17,6 +12,8 @@
 			<unit id="org.eclipse.emf.common.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.emf.common.source.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.sdk.ide" version="0.0.0"/>
+			<unit id="org.junit" version="0.0.0"/>
+			<unit id="org.junit.source" version="0.0.0"/>
 			<unit id="org.apache.commons.commons-io" version="0.0.0"/>
 			<repository location="https://download.eclipse.org/releases/2022-09"/>
 		</location>
@@ -31,13 +28,13 @@
 				<dependency>
 					<groupId>net.bytebuddy</groupId>
 					<artifactId>byte-buddy-agent</artifactId>
-					<version>1.12.16</version>
+					<version>1.12.22</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
 					<groupId>net.bytebuddy</groupId>
 					<artifactId>byte-buddy</artifactId>
-					<version>1.12.16</version>
+					<version>1.12.22</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
@@ -49,7 +46,7 @@
 				<dependency>
 					<groupId>org.mockito</groupId>
 					<artifactId>mockito-core</artifactId>
-					<version>4.9.0</version>
+					<version>5.0.0</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>

--- a/wikitext/ui/org.eclipse.mylyn.wikitext.osgi.tests/META-INF/MANIFEST.MF
+++ b/wikitext/ui/org.eclipse.mylyn.wikitext.osgi.tests/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Vendor: Eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.mylyn.wikitext;bundle-version="3.0.47",
  org.junit;bundle-version="4.8",
- org.mockito.mockito-core;bundle-version="[4.0.0,5.0.0)",
+ org.mockito.mockito-core;bundle-version="[5.0.0,6.0.0)",
  net.bytebuddy.byte-buddy,
  org.objenesis;bundle-version="[3.0.0,4.0.0)"
 Export-Package: org.eclipse.mylyn.wikitext.core.osgi;x-internal:=true

--- a/wikitext/ui/org.eclipse.mylyn.wikitext.ui.tests/META-INF/MANIFEST.MF
+++ b/wikitext/ui/org.eclipse.mylyn.wikitext.ui.tests/META-INF/MANIFEST.MF
@@ -37,7 +37,7 @@ Require-Bundle: org.junit;bundle-version="4.8",
  org.eclipse.help,
  org.apache.ant;bundle-version="1.7.0",
  org.jsoup;bundle-version="1.14.3",
- org.mockito.mockito-core;bundle-version="[4.0.0,5.0.0)",
+ org.mockito.mockito-core;bundle-version="[5.0.0,6.0.0)",
  net.bytebuddy.byte-buddy
 Export-Package: org.eclipse.mylyn.internal.wikitext.ui;x-internal:=true,
  org.eclipse.mylyn.internal.wikitext.ui.editor.syntax;x-internal:=true,


### PR DESCRIPTION
There is not need to refer to Orbit repo just for junit4 bundle.