### PR TITLE
Build against 2022-12 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -375,7 +375,7 @@
     <modules>
         <module>target-platform</module>
         <module>wikitext</module>
-        <module>epub</module>
+        <!--module>epub</module-->
         <module>docs</module>
         <module>aggregate</module>
     </modules>

--- a/target-platform/mylyn-docs.target
+++ b/target-platform/mylyn-docs.target
@@ -15,7 +15,8 @@
 			<unit id="org.junit" version="0.0.0"/>
 			<unit id="org.junit.source" version="0.0.0"/>
 			<unit id="org.apache.commons.commons-io" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/releases/2022-09"/>
+			<unit id="org.apache.commons.logging" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/releases/2022-12"/>
 		</location>
 		<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
 			<dependencies>


### PR DESCRIPTION
Disable epub plugins as they use API removed from Platform.

Fixes https://github.com/eclipse-mylyn/org.eclipse.mylyn.docs/issues/52