### PR TITLE
Fix regression in wikitext maven plugin when copying non-markup files

### DIFF
--- a/wikitext/core/org.eclipse.mylyn.wikitext.maven/src/main/java/org/eclipse/mylyn/wikitext/maven/internal/MarkupToEclipseHelpMojo.java
+++ b/wikitext/core/org.eclipse.mylyn.wikitext.maven/src/main/java/org/eclipse/mylyn/wikitext/maven/internal/MarkupToEclipseHelpMojo.java
@@ -25,6 +25,7 @@ import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -236,7 +237,7 @@ public class MarkupToEclipseHelpMojo extends AbstractMojo {
 		ensureFolderExists("target folder", targetFolder, true);
 		File targetFile = new File(targetFolder, sourceFile.getName());
 		try {
-			Files.copy(sourceFile.toPath(), targetFile.toPath());
+			Files.copy(sourceFile.toPath(), targetFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
 		} catch (IOException e) {
 			throw new BuildFailureException(
 					format("Cannot copy {0} to {1}: {2}", sourceFile, targetFile, e.getMessage()), e);

--- a/wikitext/core/org.eclipse.mylyn.wikitext.maven/src/test/java/org/eclipse/mylyn/wikitext/maven/internal/MarkupToEclipseHelpMojoTest.java
+++ b/wikitext/core/org.eclipse.mylyn.wikitext.maven/src/test/java/org/eclipse/mylyn/wikitext/maven/internal/MarkupToEclipseHelpMojoTest.java
@@ -143,6 +143,18 @@ public class MarkupToEclipseHelpMojoTest {
 	}
 
 	@Test
+	public void processNonMarkupFileOverwritesTargetFile() throws IOException {
+		URL resource = MarkupToEclipseHelpMojoTest.class.getResource("/test.textile");
+		File file = new File(resource.getPath());
+
+		markupToEclipseHelp.process(file, "", null);
+		markupToEclipseHelp.process(file, "", null);
+
+		assertTrue(computeOutputFile("test.textile").exists());
+		assertHasContent("test.textile", Files.readString(file.toPath(), StandardCharsets.UTF_8));
+	}
+
+	@Test
 	public void configureStylesheetUrls() {
 		markupToEclipseHelp.stylesheetUrls = Arrays.asList("test/foo.css", "bar.css");
 		HtmlDocumentBuilder builder = mock(HtmlDocumentBuilder.class);


### PR DESCRIPTION
The wikitext maven plugin exists to facilitate creating HTML documentation from eclipse help source files. A regression was introduced with commit
[803292b246c65c115333d12b2730a3b9759bb397](https://github.com/eclipse-mylyn/org.eclipse.mylyn.docs/commit/803292b246c65c115333d12b2730a3b9759bb397) that switched out the Guava Files.copy method for the java.nio.file.Files.copy method.

The semantics of those 2 methods are different. While Guava's copy method will always replace/overwrite the target file if it already exists, the java.nio.file.Files.copy method does not do that by default. The optional StandardCopyOption.REPLACE_EXISTING must be provided as a parameter to allow for the same behavior. This change is important if the workspace is not clean when the wikitext.maven mojo is executed.