### PR TITLE
The HtmlParser should preserve the Ideographic (CJK) Space (U+3000)

### DIFF
--- a/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/internal/parser/html/AbstractSaxHtmlParser.java
+++ b/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/internal/parser/html/AbstractSaxHtmlParser.java
@@ -295,7 +295,8 @@ public abstract class AbstractSaxHtmlParser {
 				for (int x = 0; x < length; ++x) {
 					int index = start + x;
 					char c = ch[index];
-					if (Character.isWhitespace(c)) {
+					// preserve ideographic whitespace U+3000
+					if (Character.isWhitespace(c) && c != '\u3000') {
 						if (previousWhitespaceIndex == index - 1) {
 							previousWhitespaceIndex = index;
 							continue;

--- a/wikitext/core/org.eclipse.mylyn.wikitext/src/test/java/org/eclipse/mylyn/wikitext/internal/parser/html/HtmlParserTest.java
+++ b/wikitext/core/org.eclipse.mylyn.wikitext/src/test/java/org/eclipse/mylyn/wikitext/internal/parser/html/HtmlParserTest.java
@@ -245,6 +245,36 @@ public class HtmlParserTest {
 		assertParse("<pre>some\ncode</pre>", "<body><pre>some\ncode</pre></body>");
 	}
 
+	@Test
+	public void paragraphWithSpacePreserved() {
+		assertParse("<p>foo bar</p>", "<body><p>foo bar</p></body>");
+	}
+
+	@Test
+	public void preformattedWithSpacePreserved() {
+		assertParse("<pre>foo bar</pre>", "<body><pre>foo bar</pre></body>");
+	}
+
+	@Test
+	public void paragraphWithExtraSpacesCollapsed() {
+		assertParse("<p>foo bar</p>", "<body><p>foo  bar</p></body>");
+	}
+
+	@Test
+	public void preformattedWithExtraSpacesPreserved() {
+		assertParse("<pre>foo  bar</pre>", "<body><pre>foo  bar</pre></body>");
+	}
+
+	@Test
+	public void paragraphWithIdeographicSpacePreserved() {
+		assertParse("<p>foo　bar</p>", "<body><p>foo　bar</p></body>");
+	}
+
+	@Test
+	public void preformattedWithIdeographicSpacePreserved() {
+		assertParse("<pre>foo　bar</pre>", "<body><pre>foo　bar</pre></body>");
+	}
+
 	private void assertParse(String expected, String content) {
 		StringWriter out = new StringWriter();
 		DocumentBuilder builder = new HtmlDocumentBuilder(out);


### PR DESCRIPTION
When the HtmlParser parses content, it will discard or collapse excessive whitespace unless it's processing content within a \<pre\> block. In the AbstractSaxHmltParser#append method, we can see that the parser will replace all whitespace characters with the standard space ' ', with the special exemption of preserving '\t' whitespaces. This can be problematic since there are a number of non-standard whitespace characters of various widths that will be replaced. See https://jkorpela.fi/chars/spaces.html for some examples.

Of particular relevance is the extra-wide ideograph space character 'u\3000' which holds particular importance in Chinese, Japanese, and Korean (CJK) based character sets. Since this whitespace glyph is extra-wide, collapsing it to the standard width may reduce meaning or legibility in these character sets. We would like to make a special case to preserve this character. Proposed fix incoming.