### PR TITLE
Recognize uppercase wikitext file extensions (#140)

### DIFF
--- a/wikitext/ui/org.eclipse.mylyn.wikitext.ui/src/org/eclipse/mylyn/internal/wikitext/ui/registry/WikiTextExtensionPointReader.java
+++ b/wikitext/ui/org.eclipse.mylyn.wikitext.ui/src/org/eclipse/mylyn/internal/wikitext/ui/registry/WikiTextExtensionPointReader.java
@@ -176,6 +176,7 @@ public class WikiTextExtensionPointReader {
 		}
 		int lastIndexOfDot = name.lastIndexOf('.');
 		String extension = lastIndexOfDot == -1 ? name : name.substring(lastIndexOfDot + 1);
+		extension = extension.toLowerCase();
 		Class<? extends MarkupLanguage> languageClass = languageByFileExtension.get(extension);
 		if (languageClass != null) {
 			String languageName = null;


### PR DESCRIPTION
Fixes #140.

Tested via installing a Maven build into the IDE. Wasn't able to debug from the IDE due to compile errors all over the place.